### PR TITLE
Read the last line, don't exit after getting io.EOF

### DIFF
--- a/obj/reader.go
+++ b/obj/reader.go
@@ -49,15 +49,16 @@ func (r *stdReader) Read() (*Object, error) {
 	lineNumber := int64(1)
 	for {
 		line, err := buf.ReadBytes('\n')
-		if err == io.EOF {
-			return &o, nil
-		}
+
 		if err != nil && err != io.EOF {
 			return nil, err
 		}
 
 		if err := r.readLine(string(line), lineNumber, &o); err != nil {
 			return nil, err
+		}
+		if err == io.EOF {
+			return &o, nil
 		}
 
 		lineNumber++


### PR DESCRIPTION
For a official source talking about this: https://tour.golang.org/methods/21

`io.EOF` doesn't represent that you should immediately stop reading, it represents that the value just read was useful and after processing it you should exit. Right now if you don't have an extra new line at the end of your `.obj` files, the last line will fail to be read. 

Edit: a better source, [the official documentation for bufio.ReadBytes](https://golang.org/pkg/bufio/#Reader.ReadBytes): "If ReadBytes encounters an error before finding a delimiter, it returns the data read before the error and the error itself (often io.EOF)"